### PR TITLE
NXP-10570: handle override and versioning when importing an image  - fix

### DIFF
--- a/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/java/org/nuxeo/ecm/platform/picture/extension/ImagePlugin.java
+++ b/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/java/org/nuxeo/ecm/platform/picture/extension/ImagePlugin.java
@@ -80,6 +80,7 @@ public class ImagePlugin extends AbstractFileImporter {
             docModel.setPropertyValue("dc:title", title);
             docModel.setPropertyValue("file:content",
                     (Serializable) content.persist());
+            docModel.setPropertyValue("file:filename", filename);
             docModel.setPathInfo(path, pss.generatePathSegment(docModel));
             docModel = documentManager.createDocument(docModel);
         }


### PR DESCRIPTION
https://jira.nuxeo.com/browse/NXP-10570

set file:filename property so that FileManagerUtils.getExistingDocByFileName can work : without this, it doesn't work

Thanks
