### PR TITLE
NXP-11348: Fix hard-coded Domain reference

### DIFF
--- a/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/main/java/org/nuxeo/ecm/platform/publisher/web/AbstractPublishActions.java
+++ b/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/main/java/org/nuxeo/ecm/platform/publisher/web/AbstractPublishActions.java
@@ -13,6 +13,7 @@
  *
  * Contributors:
  *     Thomas Roger
+ *     Marwane Kalam-Alami
  */
 
 package org.nuxeo.ecm.platform.publisher.web;

--- a/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/main/java/org/nuxeo/ecm/platform/publisher/web/AbstractPublishActions.java
+++ b/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/main/java/org/nuxeo/ecm/platform/publisher/web/AbstractPublishActions.java
@@ -27,6 +27,7 @@ import org.nuxeo.ecm.core.api.ClientException;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.security.SecurityConstants;
+import org.nuxeo.ecm.core.schema.types.Type;
 import org.nuxeo.ecm.platform.ui.web.api.NavigationContext;
 import org.nuxeo.ecm.webapp.helpers.ResourcesAccessor;
 
@@ -70,7 +71,8 @@ public abstract class AbstractPublishActions {
         String translatedPathElement = resourcesAccessor.getMessages().get(
                 pathElementName);
         pathFragments.add(translatedPathElement);
-        if ("Domain".equals(documentModel.getType())) {
+        
+        if (isDomain(documentModel) || "/".equals(documentModel.getPathAsString())) {
             return;
         }
 
@@ -81,5 +83,17 @@ public abstract class AbstractPublishActions {
             getPathFragments(parentDocument, pathFragments);
         }
     }
+
+    protected boolean isDomain(DocumentModel documentModel) {
+        Type type = documentModel.getDocumentType();
+        while (type != null) {
+            if ("Domain".equals(type.getName())) {
+                return true;
+            }
+            type = type.getSuperType();
+        }
+        return false;
+    }
+
 
 }

--- a/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/test/java/org/nuxeo/ecm/platform/publisher/web/DummyPublishActions.java
+++ b/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/test/java/org/nuxeo/ecm/platform/publisher/web/DummyPublishActions.java
@@ -1,3 +1,19 @@
+/*
+ * (C) Copyright 2013 Nuxeo SA (http://nuxeo.com/) and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Lesser General Public License
+ * (LGPL) version 2.1 which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * Contributors:
+ *     Marwane Kalam-Alami
+ */
 package org.nuxeo.ecm.platform.publisher.web;
 
 import org.nuxeo.ecm.core.api.CoreSession;

--- a/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/test/java/org/nuxeo/ecm/platform/publisher/web/DummyPublishActions.java
+++ b/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/test/java/org/nuxeo/ecm/platform/publisher/web/DummyPublishActions.java
@@ -1,0 +1,14 @@
+package org.nuxeo.ecm.platform.publisher.web;
+
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.webapp.helpers.ResourcesAccessor;
+
+@SuppressWarnings("deprecation")
+public class DummyPublishActions extends AbstractPublishActions {
+    
+    public DummyPublishActions(CoreSession documentManager, ResourcesAccessor resourcesAccessor) {
+        this.documentManager = documentManager;
+        this.resourcesAccessor = resourcesAccessor;
+    }
+    
+}

--- a/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/test/java/org/nuxeo/ecm/platform/publisher/web/TestPublishActions.java
+++ b/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/test/java/org/nuxeo/ecm/platform/publisher/web/TestPublishActions.java
@@ -1,0 +1,64 @@
+package org.nuxeo.ecm.platform.publisher.web;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.nuxeo.ecm.core.api.ClientException;
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.test.CoreFeature;
+import org.nuxeo.ecm.core.test.DefaultRepositoryInit;
+import org.nuxeo.ecm.core.test.annotations.Granularity;
+import org.nuxeo.ecm.core.test.annotations.RepositoryConfig;
+import org.nuxeo.ecm.webapp.helpers.ResourcesAccessorBean;
+import org.nuxeo.runtime.test.runner.Deploy;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+import org.nuxeo.runtime.test.runner.LocalDeploy;
+
+import com.google.inject.Inject;
+
+/**
+ * 
+ * @author mkalam-alami
+ *
+ */
+@SuppressWarnings("deprecation")
+@RunWith(FeaturesRunner.class)
+@Features(CoreFeature.class)
+@Deploy("org.nuxeo.ecm.platform.publisher.web")
+@LocalDeploy("org.nuxeo.ecm.platform.publisher.web:OSGI-INF/core-types-contrib.xml")
+@RepositoryConfig(init = DefaultRepositoryInit.class, user = "Administrator", cleanup = Granularity.METHOD)
+public class TestPublishActions {
+    
+    @Inject
+    private CoreSession documentManager;
+
+    @Inject
+    private ResourcesAccessorBean resourcesAccessor;
+
+    @Test(timeout = 3000) // In case an infinite loop occurs
+    public void testGetPathFragments() throws ClientException {
+        // Create file in standard domain
+        DocumentModel fileModel = documentManager.createDocumentModel("/default-domain/workspaces/", "myfile", "File");
+        fileModel = documentManager.createDocument(fileModel);
+
+        // Create file in custom domain with specific type
+        DocumentModel customDomainModel = documentManager.createDocumentModel("/", "mydomain", "CustomDomain");
+        customDomainModel = documentManager.createDocument(customDomainModel);
+        DocumentModel file2Model = documentManager.createDocumentModel(customDomainModel.getPathAsString(), "myfile2", "File");
+        file2Model = documentManager.createDocument(file2Model);
+        
+        // Create file directly below the root
+        DocumentModel file3Model = documentManager.createDocumentModel("/", "myfile3", "File");
+        file3Model = documentManager.createDocument(file3Model);
+        
+        // Test paths (every fragment is null because the message map is empty)
+        DummyPublishActions publishActions = new DummyPublishActions(documentManager, resourcesAccessor);
+        Assert.assertEquals("null>null>null", publishActions.getFormattedPath(fileModel));
+        Assert.assertEquals("null>null", publishActions.getFormattedPath(file2Model));
+        Assert.assertEquals("null>null", publishActions.getFormattedPath(file3Model));
+    }
+    
+}

--- a/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/test/java/org/nuxeo/ecm/platform/publisher/web/TestPublishActions.java
+++ b/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/test/java/org/nuxeo/ecm/platform/publisher/web/TestPublishActions.java
@@ -1,3 +1,19 @@
+/*
+ * (C) Copyright 2013 Nuxeo SA (http://nuxeo.com/) and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Lesser General Public License
+ * (LGPL) version 2.1 which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * Contributors:
+ *     Marwane Kalam-Alami
+ */
 package org.nuxeo.ecm.platform.publisher.web;
 
 import junit.framework.Assert;
@@ -19,11 +35,6 @@ import org.nuxeo.runtime.test.runner.LocalDeploy;
 
 import com.google.inject.Inject;
 
-/**
- * 
- * @author mkalam-alami
- *
- */
 @SuppressWarnings("deprecation")
 @RunWith(FeaturesRunner.class)
 @Features(CoreFeature.class)

--- a/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/test/resources/OSGI-INF/core-types-contrib.xml
+++ b/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/test/resources/OSGI-INF/core-types-contrib.xml
@@ -1,0 +1,8 @@
+<component name="org.nuxeo.ecm.platform.publisher.web.tests.types.contrib">
+
+  <require>org.nuxeo.ecm.core.CoreExtensions</require>
+  
+  <extension target="org.nuxeo.ecm.core.schema.TypeService" point="doctype">
+    <doctype extends="Domain" name="CustomDomain" />
+  </extension>
+</component>

--- a/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/test/resources/log4j.properties
+++ b/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/test/resources/log4j.properties
@@ -1,0 +1,12 @@
+#------------------------------------------------------------------------------
+# Logging configuration
+#------------------------------------------------------------------------------
+log4j.rootCategory=WARN, console
+log4j.logger.org.nuxeo.ecm.platform.publisher.web=DEBUG
+
+#------------------------------------------------------------------------------
+# Console appender
+#------------------------------------------------------------------------------
+log4j.appender.console = org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout = org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern = %d{HH:mm:ss,SSS} %-5p [%C{1}] %m%n


### PR DESCRIPTION
Updated fix for https://jira.nuxeo.com/browse/NXP-11348

This time, getPathFragments() looks for a Domain or a subtype of Domain. I left a test for the root path to avoid infinite loops in all situations (e.g. a publication tree not based on a domain).
