### PR TITLE
NXP-11352: Fix wrong handling of the '|' separator for the sortInfos param

### DIFF
--- a/nuxeo-automation/nuxeo-automation-features/src/main/java/org/nuxeo/ecm/automation/core/operations/services/DocumentPageProviderOperation.java
+++ b/nuxeo-automation/nuxeo-automation-features/src/main/java/org/nuxeo/ecm/automation/core/operations/services/DocumentPageProviderOperation.java
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Thierry Delprat
+ *     Marwane Kalam-Alami
  */
 package org.nuxeo.ecm.automation.core.operations.services;
 
@@ -52,6 +53,8 @@ public class DocumentPageProviderOperation {
     public static final String CURRENT_USERID_PATTERN = "$currentUser";
 
     public static final String CURRENT_REPO_PATTERN = "$currentRepository";
+
+    private static final String SORT_PARAMETER_SEPARATOR = " ";
 
     @Context
     protected OperationContext context;
@@ -100,8 +103,8 @@ public class DocumentPageProviderOperation {
             sortInfos = new ArrayList<SortInfo>();
             for (String sortInfoDesc : sortInfoAsStringList) {
                 SortInfo sortInfo;
-                if (sortInfoDesc.contains("|")) {
-                    String[] parts = sortInfoDesc.split("|");
+                if (sortInfoDesc.contains(SORT_PARAMETER_SEPARATOR)) {
+                    String[] parts = sortInfoDesc.split(SORT_PARAMETER_SEPARATOR);
                     sortInfo = new SortInfo(parts[0],
                             Boolean.parseBoolean(parts[1]));
                 } else {


### PR DESCRIPTION
See https://jira.nuxeo.com/browse/NXP-11352

Assuming this option for the sorting direction never worked, I switched the character to a space, for consistency with operation "Social.Provider" (class SocialProviderOperation).

**EDIT:** If this gets merged, the documentation at http://explorer.nuxeo.org/nuxeo/site/distribution/current/viewOperation/Document.PageProvider will have to be updated. It has to be anyway since the documentation itself has an additional mistake: the actual default sorting direction is the ascending one.
