### PR TITLE
NXP-11582: Updated metadata-extractor and removed older mistral references

### DIFF
--- a/nuxeo-platform-imaging/nuxeo-platform-imaging-api/src/main/java/org/nuxeo/ecm/platform/picture/api/MetadataConstants.java
+++ b/nuxeo-platform-imaging/nuxeo-platform-imaging-api/src/main/java/org/nuxeo/ecm/platform/picture/api/MetadataConstants.java
@@ -25,10 +25,6 @@ package org.nuxeo.ecm.platform.picture.api;
  */
 public class MetadataConstants {
 
-    public static final String META_WIDTH = "width";
-
-    public static final String META_HEIGHT = "height";
-
     /* EXIF */
     public static final String META_DESCRIPTION = "description";
 

--- a/nuxeo-platform-imaging/nuxeo-platform-imaging-api/src/main/java/org/nuxeo/ecm/platform/picture/api/adapters/AbstractPictureAdapter.java
+++ b/nuxeo-platform-imaging/nuxeo-platform-imaging-api/src/main/java/org/nuxeo/ecm/platform/picture/api/adapters/AbstractPictureAdapter.java
@@ -42,7 +42,6 @@ import static org.nuxeo.ecm.platform.picture.api.MetadataConstants.META_EXPOSURE
 import static org.nuxeo.ecm.platform.picture.api.MetadataConstants.META_FNUMBER;
 import static org.nuxeo.ecm.platform.picture.api.MetadataConstants.META_FOCALLENGTH;
 import static org.nuxeo.ecm.platform.picture.api.MetadataConstants.META_HEADLINE;
-import static org.nuxeo.ecm.platform.picture.api.MetadataConstants.META_HEIGHT;
 import static org.nuxeo.ecm.platform.picture.api.MetadataConstants.META_HRESOLUTION;
 import static org.nuxeo.ecm.platform.picture.api.MetadataConstants.META_ICCPROFILE;
 import static org.nuxeo.ecm.platform.picture.api.MetadataConstants.META_ISOSPEED;
@@ -66,7 +65,6 @@ import static org.nuxeo.ecm.platform.picture.api.MetadataConstants.META_TIME_CRE
 import static org.nuxeo.ecm.platform.picture.api.MetadataConstants.META_URGENCY;
 import static org.nuxeo.ecm.platform.picture.api.MetadataConstants.META_VRESOLUTION;
 import static org.nuxeo.ecm.platform.picture.api.MetadataConstants.META_WHITEBALANCE;
-import static org.nuxeo.ecm.platform.picture.api.MetadataConstants.META_WIDTH;
 import static org.nuxeo.ecm.platform.picture.api.MetadataConstants.META_WRITER;
 
 import java.awt.*;
@@ -198,21 +196,15 @@ public abstract class AbstractPictureAdapter implements PictureResourceAdapter {
     }
 
     protected void setMetadata() throws IOException, ClientException {
-        boolean imageInfoUsed = false;
         ImageInfo imageInfo = getImagingService().getImageInfo(fileContent);
         if (imageInfo != null) {
             width = imageInfo.getWidth();
             height = imageInfo.getHeight();
             depth = imageInfo.getDepth();
-            imageInfoUsed = true;
         }
         Map<String, Object> metadata = getImagingService().getImageMetadata(
                 fileContent);
         description = (String) metadata.get(META_DESCRIPTION);
-        if (!imageInfoUsed) {
-            width = (Integer) metadata.get(META_WIDTH);
-            height = (Integer) metadata.get(META_HEIGHT);
-        }
         doc.setPropertyValue("picture:" + FIELD_BYLINE,
                 (String) metadata.get(META_BY_LINE));
         doc.setPropertyValue("picture:" + FIELD_CAPTION,

--- a/nuxeo-platform-imaging/nuxeo-platform-imaging-core/pom.xml
+++ b/nuxeo-platform-imaging/nuxeo-platform-imaging-core/pom.xml
@@ -43,16 +43,10 @@
 
     <!-- Mistral -->
     <dependency>
-      <groupId>net.java.dev.mistral</groupId>
-      <artifactId>EditableImage</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>net.java.dev.mistral</groupId>
-      <artifactId>Operations</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>net.java.dev.mistral</groupId>
+      <groupId>com.drewnoakes</groupId>
       <artifactId>metadata-extractor</artifactId>
+      <!-- TODO: Move the version to dependency management -->
+      <version>2.6.4</version>
     </dependency>
 
     <dependency>

--- a/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/java/org/nuxeo/ecm/platform/picture/ImagingComponent.java
+++ b/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/java/org/nuxeo/ecm/platform/picture/ImagingComponent.java
@@ -106,8 +106,7 @@ public class ImagingComponent extends DefaultComponent implements
     @Override
     public Map<String, Object> getImageMetadata(Blob blob) {
         try {
-            return getLibrarySelectorService().getMetadataUtils().getImageMetadata(
-                    blob);
+            return getLibrarySelectorService().getMetadataUtils().getImageMetadata(blob);
         } catch (Exception e) {
             log.error(e.getMessage(), e);
         }

--- a/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/test/java/org/nuxeo/ecm/platform/picture/core/test/TestExifHelper.java
+++ b/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/test/java/org/nuxeo/ecm/platform/picture/core/test/TestExifHelper.java
@@ -82,6 +82,6 @@ public class TestExifHelper {
         Map<String, Object> metadatas = service.getImageMetadata(blob);
         String userComment = ((String) metadatas.get(MetadataConstants.META_COMMENT)).trim();
         assertNotSame("ASCII", userComment);
-        assertEquals("(C) PAULO BRANDA", userComment);
+        assertEquals("(C) PAULO BRANDAO", userComment);
     }
 }

--- a/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/test/java/org/nuxeo/ecm/platform/picture/core/test/TestMetaDataService.java
+++ b/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/test/java/org/nuxeo/ecm/platform/picture/core/test/TestMetaDataService.java
@@ -79,11 +79,9 @@ public class TestMetaDataService extends NXRuntimeTestCase {
         assertNotNull(map.get(MetadataConstants.META_CREDIT));
         assertNotNull(map.get(MetadataConstants.META_DATE_CREATED));
         assertNotNull(map.get(MetadataConstants.META_HEADLINE));
-        assertNotNull(map.get(MetadataConstants.META_HEIGHT));
         assertNotNull(map.get(MetadataConstants.META_OBJECT_NAME));
         assertNotNull(map.get(MetadataConstants.META_SOURCE));
         assertNotNull(map.get(MetadataConstants.META_SUPPLEMENTAL_CATEGORIES));
-        assertNotNull(map.get(MetadataConstants.META_WIDTH));
 
         // those metadata are not found by the parser
         // assertNotNull(map.get(MetadataConstants.META_COMMENT));


### PR DESCRIPTION
Initial work on removing mistral references and relying only on metadata-extractor (https://code.google.com/p/metadata-extractor/)
