### PR TITLE
NXP-14603: Write multipart boundary in the Content-Type header

### DIFF
--- a/nuxeo-automation/nuxeo-automation-io/src/main/java/org/nuxeo/ecm/automation/jaxrs/io/documents/BlobsWriter.java
+++ b/nuxeo-automation/nuxeo-automation-io/src/main/java/org/nuxeo/ecm/automation/jaxrs/io/documents/BlobsWriter.java
@@ -39,6 +39,7 @@ public class BlobsWriter implements MessageBodyWriter<MultipartBlobs> {
             MultivaluedMap<String, Object> httpHeaders,
             OutputStream entityStream) throws IOException {
         try {
+            httpHeaders.putSingle("Content-Type", blobs.getContentType());
             blobs.writeTo(entityStream);
             entityStream.flush();
         } catch (MessagingException e) {


### PR DESCRIPTION
The content type header was already right in MultipartBlobs so I just wrote it in the headers in BlobsWriter.
