### PR TITLE
NXP-15437: Picture orientation is not detected properly

### DIFF
--- a/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/resources/OSGI-INF/commandline-imagemagick-contrib.xml
+++ b/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/resources/OSGI-INF/commandline-imagemagick-contrib.xml
@@ -22,8 +22,8 @@
 
     <command name="resizer" enabled="true">
       <commandLine>convert</commandLine>
-      <parameterString>-quiet -depth #{targetDepth} #{inputFilePath}[0] jpg:- | convert - -resize #{targetWidth}x#{targetHeight} #{outputFilePath}</parameterString>
-      <winParameterString>-quiet -depth #{targetDepth} #{inputFilePath}[0] -resize #{targetWidth}x#{targetHeight} #{outputFilePath}</winParameterString>
+      <parameterString>-quiet -auto-orient -depth #{targetDepth} #{inputFilePath}[0] jpg:- | convert - -resize #{targetWidth}x#{targetHeight} #{outputFilePath}</parameterString>
+      <winParameterString>-quiet -auto-orient -depth #{targetDepth} #{inputFilePath}[0] -resize #{targetWidth}x#{targetHeight} #{outputFilePath}</winParameterString>
       <installationDirective>You need to install ImageMagic.</installationDirective>
     </command>
 

--- a/nuxeo-thumbnail/src/main/resources/OSGI-INF/thumbnail-commandline-imagemagick-contrib.xml
+++ b/nuxeo-thumbnail/src/main/resources/OSGI-INF/thumbnail-commandline-imagemagick-contrib.xml
@@ -8,8 +8,8 @@
 
     <command name="toThumbnail" enabled="true">
       <commandLine>convert</commandLine>
-      <parameterString>-quiet -strip -thumbnail #{size} -background transparent -gravity center -format png -quality 75 #{inputFilePath}[0] #{outputFilePath}</parameterString>
-      <winParameterString>-quiet -strip -thumbnail #{size} -background transparent -gravity center -format png -quality 75 #{inputFilePath}[0] #{outputFilePath}</winParameterString>
+      <parameterString>-quiet -strip -thumbnail #{size} -auto-orient -background transparent -gravity center -format png -quality 75 #{inputFilePath}[0] #{outputFilePath}</parameterString>
+      <winParameterString>-quiet -strip -thumbnail #{size} -auto-orient -background transparent -gravity center -format png -quality 75 #{inputFilePath}[0] #{outputFilePath}</winParameterString>
       <installationDirective>You need to install ImageMagick.</installationDirective>
     </command>
 


### PR DESCRIPTION
Adding the `-auto-orient` parameter to the `ImageMagick` command line arguments. Cf http://www.imagemagick.org/script/command-line-options.php#auto-orient

The potential problem is the one described in IM doc...

> This operator reads and resets the EXIF image profile setting 'Orientation' and then performs the appropriate 90 degree rotation on the image to orient the image, for correct viewing.
> 
> This EXIF profile setting is usually set using a gravity sensor in digital camera, however photos taken directly downward or upward may not have an appropriate value. Also images that have been orientation 'corrected' without reseting this setting, may be 'corrected' again resulting in a incorrect result

...so using `-auto-orient` could, maybe, lead to incorrect orientation on some pictures?
